### PR TITLE
chore: add detailed cookie retrieval logs

### DIFF
--- a/src/ref_main.py
+++ b/src/ref_main.py
@@ -265,7 +265,7 @@ def down_text(it, mod=1):
     while retry_count < max_retries:
         try:
             # 使用新API获取内容
-            api_url = f"http://yuefanqie.jingluo.love/content?item_id={it}"
+            api_url = f"http://rehaofan.jingluo.love/content?item_id={it}"
             response = network_manager.make_request(api_url)
             data = response.json()
             


### PR DESCRIPTION
## Summary
- add verbose status messages for cookie initialization and testing
- log progress and attempts during cookie enumeration
- point ref_main content API to rehaofan.jingluo.love

## Testing
- `python -m py_compile src/ref_main.py`
- `python -m py_compile src/main.py`


------
https://chatgpt.com/codex/tasks/task_b_68b0b427caf4832ba5d2a8d2cab4ceed